### PR TITLE
fix website link for reactivemaps

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,8 +210,8 @@
                   </span>
                 </div>
                 <div class="menu-item-info">
-                  <p class="menu-item-description">http://opensource.appbase.io/reactivemaps - A data aware UI components library for building realtime maps</p>
-                  <span class="menu-item-price"><a href="https://github.com/appbaseio/reactivemaps" target="_blank">GitHub</a></span>
+                  <p class="menu-item-description">A data aware UI components library for building realtime maps</p>
+                  <span class="menu-item-price"><a href="http://opensource.appbase.io/reactivemaps" target="_blank">Website</a> &middot; <a href="https://github.com/appbaseio/reactivemaps" target="_blank">GitHub</a></span>
                 </div>
               </li>
               <li class="menu-item">


### PR DESCRIPTION
Hi guys, 
i walked around your site and found some bug with website link for reactivemaps library on the bottom of the main page. I made fork and fixed it, but then noticed that this index.html file generated automatically by ci, then i dive into python script and found that root of this bug in another place.

![bug-on-the-site](https://user-images.githubusercontent.com/249886/34689884-bac4b8de-f4bf-11e7-9c1c-a3824ef61a61.png)

Seems like python script pull repositories info from github and generate that widgets with links. And all is ok for other repositories except that mentioned **reactivemaps**. In this repository website link placed in _description_ field instead of _website_ field. Look at attached screenshots for clarity.

<img width="530" alt="python-script" src="https://user-images.githubusercontent.com/249886/34690033-40b34db6-f4c0-11e7-86c2-783b58e0496f.png">
<img width="1018" alt="repositories-info" src="https://user-images.githubusercontent.com/249886/34690043-4597c9ba-f4c0-11e7-8afa-1a9df3dd8672.png">


So, i think if you will edit info for **reactivemaps** repository and place website link in proper field, then regenerate index.html - this bug will disappear and website link will appear in proper place on the opensource.appbase.io site.

Opensource is power 💪
Good luck!